### PR TITLE
Fixed high CPU usage caused by constantly recalculating counters

### DIFF
--- a/src/lib/GitHubAPI/github_api.js
+++ b/src/lib/GitHubAPI/github_api.js
@@ -24,7 +24,6 @@ class GitHubGraphQL {
         const result = await graphql(
             body,
             {
-
                 headers: {
                   authorization: `token ${this.access_token}`,
                 },


### PR DESCRIPTION
This was caused browser to execute querySelectorAll almost all the time. Fixed by removing reactivity and re-calculating counters explicitly with a timeout and only once per multiple requests.