### PR TITLE
Fix comments

### DIFF
--- a/src/lib/GitHubPrCard.svelte
+++ b/src/lib/GitHubPrCard.svelte
@@ -56,8 +56,13 @@
         if (!last_n)
             last_n = pr.comments.nodes.length;
 
+        // Sort in reverse chronological order, (so the newest is at pos 0).
+        let sorted_comments = pr.comments.nodes.toSorted((a, b) => {
+            return a.updatedAt - b.updatedAt;
+        });
+
         let comments = [];
-        for (let comment of pr.comments.nodes.slice(pr.comments.nodes.length - last_n)) {
+        for (let comment of sorted_comments.slice(sorted_comments.length - last_n)) {
             comments.push(`${comment.updatedAt} ${comment.author.name}:\n${comment.body}`)
         }
 

--- a/src/lib/GitHubRepoPrs.svelte
+++ b/src/lib/GitHubRepoPrs.svelte
@@ -145,7 +145,7 @@
             <div
                 class=counters
                 >
-                    total {prs_loaded.length}, displayed {prs_shown_count}
+                    showing {prs_shown_count} of {prs_loaded.length}
             </div>
     </h2>
 {#if prs_loading_error}


### PR DESCRIPTION
Displaying last N comments in reverse-chronological order (newest first)
Minor tweaks to the way total number of displayed PRs text